### PR TITLE
Consistently use _createState and _freeState from xxhash API to avoid memory misalignment

### DIFF
--- a/src/xxhash3.h
+++ b/src/xxhash3.h
@@ -33,7 +33,7 @@ private:
   napi_env env_;
   napi_ref wrapper_;
   XXH64_hash_t seed_;
-  XXH3_state_t state_;
+  XXH3_state_t* state_ = NULL;
   void *secret_ = NULL;
   size_t secretSize_;
 };

--- a/src/xxhash32.h
+++ b/src/xxhash32.h
@@ -32,7 +32,7 @@ private:
   napi_env env_;
   napi_ref wrapper_;
   XXH32_hash_t seed_;
-  XXH32_state_t state_;
+  XXH32_state_t* state_ = NULL;
 };
 
 #endif

--- a/src/xxhash64.h
+++ b/src/xxhash64.h
@@ -32,7 +32,7 @@ private:
   napi_env env_;
   napi_ref wrapper_;
   XXH64_hash_t seed_;
-  XXH64_state_t state_;
+  XXH64_state_t* state_ = NULL;
 };
 
 #endif


### PR DESCRIPTION

Fixes #3 