### PR TITLE
Move jest to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "engines": {
     "node": ">=8.6.0 <9.0.0 || >=10.0.0"
   },
-  "dependencies": {
+  "devDependencies": {
     "jest": "^25.5.4"
   }
 }


### PR DESCRIPTION
Jest being part of dependencies instead of devDependencies causes `npm i xxhash-addon` to install 532 other packages, including a ton of deprecated packages and packages w/ security vulnerabilities, all of which are unnecessary bloat not needed for actually using xxhash-addon.