### PR TITLE
Auto-discover Release and Debug builds

### DIFF
--- a/xxhash-addon.js
+++ b/xxhash-addon.js
@@ -1,3 +1,8 @@
-module.exports = {
-   ...require(process.env.DEBUG === undefined ? './build/Release/addon' : './build/Debug/addon')
-};
+try {
+  var addon = require('./build/Release/addon');
+} catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') throw e;
+  var addon = require('./build/Debug/addon');
+}
+
+module.exports = addon;


### PR DESCRIPTION
I have an Eleventy blog and I use the xxHash in it. Everything works fine, but I noticed when I start the Eleventy engine in debug mode I get an error:

```
$ DEBUG=Eleventy* npx @11ty/eleventy --serve
...
[11ty] 1. Error in your Eleventy config file '.eleventy.js'. You may need to run `npm install`. (via EleventyConfigError)
  Eleventy:EleventyErrorHandler (error stack): EleventyConfigError: Error in your Eleventy config file '.eleventy.js'. You may need to run `npm install`.
  Eleventy:EleventyErrorHandler     at TemplateConfig.requireLocalConfigFile (file:///home/sashee/workspace/awm/blog/node_modules/@11ty/eleventy/src/TemplateConfig.js:335:11
)
  Eleventy:EleventyErrorHandler     at async TemplateConfig.mergeConfig (file:///home/sashee/workspace/awm/blog/node_modules/@11ty/eleventy/src/TemplateConfig.js:357:21)
  Eleventy:EleventyErrorHandler     at async TemplateConfig.init (file:///home/sashee/workspace/awm/blog/node_modules/@11ty/eleventy/src/TemplateConfig.js:167:17)
  Eleventy:EleventyErrorHandler     at async Eleventy.initializeConfig (file:///home/sashee/workspace/awm/blog/node_modules/@11ty/eleventy/src/Eleventy.js:155:3)
  Eleventy:EleventyErrorHandler     at async Eleventy.init (file:///home/sashee/workspace/awm/blog/node_modules/@11ty/eleventy/src/Eleventy.js:408:4) +0ms
[11ty] 2. Cannot find module './build/Debug/addon'
[11ty] Require stack:
[11ty] - /home/sashee/workspace/awm/blog/node_modules/xxhash-addon/xxhash-addon.js (via Error)
  Eleventy:EleventyErrorHandler (error stack): Error: Cannot find module './build/Debug/addon'
  Eleventy:EleventyErrorHandler Require stack:
  Eleventy:EleventyErrorHandler - /home/sashee/workspace/awm/blog/node_modules/xxhash-addon/xxhash-addon.js
  Eleventy:EleventyErrorHandler     at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
  Eleventy:EleventyErrorHandler     at Module._load (node:internal/modules/cjs/loader:985:27)
  Eleventy:EleventyErrorHandler     at Module.require (node:internal/modules/cjs/loader:1235:19)
  Eleventy:EleventyErrorHandler     at require (node:internal/modules/helpers:176:18)
  Eleventy:EleventyErrorHandler     at Object.<anonymous> (/home/sashee/workspace/awm/blog/node_modules/xxhash-addon/xxhash-addon.js:2:7)
  Eleventy:EleventyErrorHandler     at Module._compile (node:internal/modules/cjs/loader:1376:14)
  Eleventy:EleventyErrorHandler     at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
  Eleventy:EleventyErrorHandler     at Module.load (node:internal/modules/cjs/loader:1207:32)
  Eleventy:EleventyErrorHandler     at Module._load (node:internal/modules/cjs/loader:1023:12)
  Eleventy:EleventyErrorHandler     at cjsLoader (node:internal/modules/esm/translators:356:17) +0ms
```

After some investigation I found that the problem is in the xxhash-addon.js:

```js
module.exports = {
   ...require(process.env.DEBUG === undefined ? './build/Release/addon' : './build/Debug/addon')
};
```

When I run ```npm install```, node-gyp generates the Release files:

```
$ ls -l node_modules/xxhash-addon/build
total 48
-rw-r--r-- 1 sashee sashee  4198 Dec 18 12:58 addon.target.mk
-rw-r--r-- 1 sashee sashee   113 Dec 18 12:58 binding.Makefile
-rw-r--r-- 1 sashee sashee 15717 Dec 18 12:58 config.gypi
-rw-r--r-- 1 sashee sashee 13704 Dec 18 12:58 Makefile
drwxr-xr-x 4 sashee sashee  4096 Dec 18 12:58 Release
```

But when I define the ```DEBUG``` environment variable it tries to load the Debug files:

```js
...require(process.env.DEBUG === undefined ? './build/Release/addon' : './build/Debug/addon')
```

I found [this conversation](https://github.com/nodejs/node-gyp/issues/743) and that hinted that it's better to try to load the release first and fall back to the debug one, which is perfect for my use-case.

I adopted the code in this PR from [here](https://github.com/bnoordhuis/node-heapdump/blob/master/index.js#L15) as it seems even more robust than the one in the conversation.