### PR TITLE
Add -march=native to release builds for optimal SIMD vectorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Minimum supported Node.js version is now 20 (dropping 8, 10, 12, 14, 16, 18)
 ### Performance
 - Enable `XXH3_STREAM_USE_STACK` for ~2x faster XXH3 and XXH128 streaming throughput on Apple Silicon with clang
+- Add `-march=native` to release builds for optimal SIMD vectorization (enables AVX2 on x86_64 instead of SSE2 baseline)
 ### CI
 - Update GitHub Actions to test Node.js 20, 22, 24
 - Update AppVeyor to test Node.js 20, 22, 24

--- a/binding.gyp
+++ b/binding.gyp
@@ -72,6 +72,7 @@
             "cflags": [
               "-O3",
               "-std=c99",
+              "-march=native",
             ],
             "defines": [
               "XXH3_STREAM_USE_STACK=1",
@@ -87,6 +88,7 @@
               "OTHER_CFLAGS": [
                 "-O3",
                 "-std=c99",
+                "-march=native",
               ]
             }
           }


### PR DESCRIPTION
  Summary                                                                                                                                                                                                             
                                                                                                                                                                                                                      
  - Add -march=native to cflags and xcode_settings in the release build configuration                                                                                                                                 
  - XXH3 on Linux x64 was limited to SSE2 (128-bit SIMD) because the default x86-64 compiler target doesn't enable AVX2                                                                                               
  - The AMD EPYC 7763 CI runners support AVX2 (256-bit), which should roughly double XXH3/XXH128 streaming throughput from ~18 GB/s to ~35+ GB/s                                                                      
  - Since xxhash-addon always builds from source on npm install, -march=native is safe — the binary targets the user's actual CPU                                                                                     
                                                                                                                                                                                                                      
  Test plan                                                                                                                                                                                                           
                                                                                                                                                                                                                      
  - Verify npm test passes on all CI platforms                                                                                                                                                                        
  - Compare Linux x64 XXH3 throughput before (~18 GB/s) and after (expected ~35+ GB/s)                                                                                                                                
  - Verify macOS arm64 throughput is unchanged (~34 GB/s)                                                                                                                                                             
  - Verify Windows builds still work (MSVC ignores -march=native; uses its own flags)                                                                                                                                 

